### PR TITLE
+ [ Changed Web Server to PHP Built-in one ]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,48 @@
-FROM php:apache
+# Disclaimer: This Dockerfile is provided as-is without any warranty. This uses
+#             PHP's built-in web server, it is indended for development
+#             purposes only and is not suitable for production. Use at your own
+#             risk.
 
-LABEL maintainer="priorist <contact@priorist.com>"
+# Latest base of Official Alpine 
+FROM alpine:latest
 
-# Use the default production configuration
-RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+# Taking responsibility
+LABEL maintainer="Harry S <git@harrysy.red>"
 
-# Copy contents of document root
-COPY --chown=www-data:www-data src /var/www/html
+# Removing responsibility
+RUN echo "Disclaimer: This Dockerfile is provided as-is without any warranty. Use at your own risk."
+
+# Installing PHP and cleaning up packet cache
+RUN apk update && \
+    apk add php && \
+    rm -rf /var/cache/apk/*
+
+# Alpine already using php.ini-production as ini file. Run command below to
+# verify:
+# grep -q "This is the php.ini-production INI" php.ini && echo "Prod"
+
+# Copy content from src to 'html' folder 
+COPY --chown=www-data:www-data src /html
+
+# Adding less privilaged user
+RUN adduser -D -H -u 1000 -G www-data www-data
+
+# Changing to less privilaged user for more security
+USER www-data
+
+# Starting PHP built-in HTTP *development* server hosting files in the 'html'
+# folder
+CMD ["php", "-S", "0.0.0.0:80", "-t", "/html"]
+
+# -S addr:port
+#    Start built-in web server on the given local address and port.
+#    Set to 0.0.0.0 to listen for external connections.
+# -t document_root
+#    Specify the document root to be used by the built-in web server.
+# Note: The built-in web server is intended for development purposes and is not
+# suitable for production.
+
+# Exposes port 80 (http) to allow external connections on port 80 for tcp
+# traffic
+EXPOSE 80/tcp
+

--- a/LICENSE
+++ b/LICENSE
@@ -187,6 +187,7 @@
       identification within third-party archives.
 
    Copyright [yyyy] [name of copyright owner]
+   Copyright 2024 Harry Syred <git@harrysy.red>
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
I have modified the docker build file (Dockerfile) to use PHP's Built-in Web Server instead of Apache, I have also changed the base image to from a Debian based image to Alpine further reducing the image size.

This reduces the image size from `410 MB` to `18.6 MB`.

One side effect is that PHP Built-in Web Server is designed to aid application development not to be a full-featured web server thus may not be suitable for production.